### PR TITLE
Fix two problem

### DIFF
--- a/src/tableFactory.ts
+++ b/src/tableFactory.ts
@@ -35,19 +35,24 @@ class TableValidator {
     }
 
     private static isSeparator(cellValue: string, isFirstOrLast: boolean): boolean {
-        if (cellValue.trim() == "-")
-            return true;
+        // if (cellValue.trim() == "-")
+        // return true;
         // If the first or last column is empty then it still can be a header containing separator, 
         // for example table starting or ending with borders ("|") would produce this.
         if (cellValue.trim() == "" && isFirstOrLast)
             return true;
-        return false;
+        
+        // If the column containing more "-"
+        for (let v of cellValue.trim()) {
+            if (v !== "-") return false;
+        }
+        return true;
     }
 
     public static areValidRows(rawRows: string[][]): boolean {
-        return !!rawRows && 
-                rawRows.length > 1 && // at least two rows are required
-                rawRows[0].length > 1 && // at least two columns are required
-                rawRows.every(r => r.length == rawRows[0].length); // all rows of a column must match the length of the first row of that column
+        return !!rawRows &&
+            rawRows.length > 1 && // at least two rows are required
+            rawRows[0].length > 1 && // at least two columns are required
+            rawRows.every(r => r.length == rawRows[0].length); // all rows of a column must match the length of the first row of that column
     }
 }

--- a/test/column.test.ts
+++ b/test/column.test.ts
@@ -29,35 +29,39 @@ suite("Column Tests", () => {
     });
 
     test("getValue() first column gives expected values right padded to header length", () => {
-        const column = new Column(new RawColumn(["Header row", "row 1","row 2"]), ColumnPositioning.First);
+        const column = new Column(new RawColumn(["Header row", "row 1","row 2", "中文"]), ColumnPositioning.First);
         assert.equal(column.getValue(0), "Header row ");
         assert.equal(column.getValue(1), "-----------");
         assert.equal(column.getValue(2), "row 1      ");
         assert.equal(column.getValue(3), "row 2      ");
+        assert.equal(column.getValue(4), "中文       ");
     });
 
     test("getValue() first column gives expected values right padded to longest row length", () => {
-        const column = new Column(new RawColumn(["Header row", "very long first row","row 2"]), ColumnPositioning.First);
+        const column = new Column(new RawColumn(["Header row", "very long first row","row 2", "中文"]), ColumnPositioning.First);
         assert.equal(column.getValue(0), "Header row          ");
         assert.equal(column.getValue(1), "--------------------");
         assert.equal(column.getValue(2), "very long first row ");
         assert.equal(column.getValue(3), "row 2               ");
+        assert.equal(column.getValue(4), "中文                ");
     });
 
     test("getValue() middle column gives expected values padded to header length", () => {
-        const column = new Column(new RawColumn(["Header row", "row 1","row 2"]), ColumnPositioning.Middle);
+        const column = new Column(new RawColumn(["Header row", "row 1","row 2", "中文"]), ColumnPositioning.Middle);
         assert.equal(column.getValue(0), " Header row ");
         assert.equal(column.getValue(1), "------------");
         assert.equal(column.getValue(2), " row 1      ");
         assert.equal(column.getValue(3), " row 2      ");
+        assert.equal(column.getValue(4), " 中文       ");
     });
 
     test("getValue() middle column gives expected values padded to longest row length", () => {
-        const column = new Column(new RawColumn(["Header row", "very long first row","row 2"]), ColumnPositioning.Middle);
+        const column = new Column(new RawColumn(["Header row", "very long first row","row 2", "中文"]), ColumnPositioning.Middle);
         assert.equal(column.getValue(0), " Header row          ");
         assert.equal(column.getValue(1), "---------------------");
         assert.equal(column.getValue(2), " very long first row ");
         assert.equal(column.getValue(3), " row 2               ");
+        assert.equal(column.getValue(4), " 中文                ");
     });
 
     test("getValue() last column gives expected values with only the separator having padded to header length", () => {

--- a/test/tableFactory.test.ts
+++ b/test/tableFactory.test.ts
@@ -67,4 +67,14 @@ suite("TableFactory tests", () => {
         assert.equal(true, table != null);
         assert.equal(true, (table as ITable) != null);
     });
+
+    test("create() two column header with separator with multiple '-' and a row table instance created", () => {
+        const text = `header 1 | header 2
+                      -----|--
+                      value 1 | value 2`;
+        const factory = new TableFactory();
+        const table = factory.create(text);
+        assert.equal(true, table != null);
+        assert.equal(true, (table as ITable) != null);
+    });    
 });


### PR DESCRIPTION
When I use the extension, I found tow problems.

First, after the first format, the separator contains multiple '-', so the continues format failed.
Second, when the table contains CJK chars, such as chinese, the cellLength is correct. 