### PR TITLE
Limit table formatting input to 1M chars by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ os:
 - linux
 
 before_install:
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
+  - |
+    if [ $TRAVIS_OS_NAME == "linux" ]; then
+      export DISPLAY=':99.0'
+      /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
     fi
 
 install:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-table-prettify",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-table-prettify",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-table-prettify",
   "displayName": "Markdown Table Prettifier",
   "description": "Transforms markdown tables to be more readable.",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "publisher": "darkriszty",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
           "type": "boolean",
           "default": true,
           "description": "Whether or not show window messages."
+        },
+        "markdownTablePrettify.maxTextLength": {
+          "type": "integer",
+          "default": 1000000,
+          "description": "The maximum text length to apply formatting to."
         }
       }
     }

--- a/src/extension/sizeLimitCheker.ts
+++ b/src/extension/sizeLimitCheker.ts
@@ -1,0 +1,24 @@
+import { ILogger } from "../diagnostics/logger";
+
+export class SizeLimitChecker {
+    constructor(
+        private readonly _loggers: ILogger[],
+        private readonly _maxTextLength: number
+    ){}
+
+    public get maxTextLength() : number {
+        return this._maxTextLength;
+    }
+
+    public isWithinAllowedSizeLimit(text: string): boolean {
+        const whithinLimit = text.length <= this._maxTextLength;
+        this.logWhenTooBig(whithinLimit);
+        return whithinLimit;
+    }
+
+    private logWhenTooBig(whithinLimit: boolean) {
+        if (!whithinLimit) {
+            this._loggers.forEach(_ => _.logInfo(`Skipped markdown table prettifying due to text size limit. Configure this in the extension settings (current limit: ${this._maxTextLength} chars).`));
+        }
+    }
+}

--- a/src/extension/tableDocumentPrettyfier.ts
+++ b/src/extension/tableDocumentPrettyfier.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { SizeLimitChecker } from "./sizeLimitCheker";
 import { TableDocumentRangePrettyfier } from "./tableDocumentRangePrettyfier";
 import { TableFinder } from "../tableFinding/tableFinder";
 
@@ -6,14 +7,18 @@ export class TableDocumentPrettyfier implements vscode.DocumentFormattingEditPro
 
     constructor(
         private readonly _tableFinder: TableFinder,
-        private readonly _tableDocumentRangePrettyfier: TableDocumentRangePrettyfier
+        private readonly _tableDocumentRangePrettyfier: TableDocumentRangePrettyfier,
+        private readonly _sizeLimitChecker: SizeLimitChecker
     ) { }
 
     public provideDocumentFormattingEdits(document: vscode.TextDocument, 
         options: vscode.FormattingOptions, token: vscode.CancellationToken): vscode.TextEdit[] 
     {
         let result: vscode.TextEdit[] = [];
-        let tables: vscode.Range[] = this._tableFinder.getTables(document);
+
+        let tables: vscode.Range[] = this._sizeLimitChecker.isWithinAllowedSizeLimit(document.getText())
+            ? this._tableFinder.getTables(document)
+            : [];
         for (let tableRange of tables) {
             let edits = this._tableDocumentRangePrettyfier.provideDocumentRangeFormattingEdits(document, tableRange, options, token);
             result = result.concat(edits);

--- a/test/stubs/markdownTextDocumentStub.ts
+++ b/test/stubs/markdownTextDocumentStub.ts
@@ -11,6 +11,8 @@ export class MarkdownTextDocumentStub implements vscode.TextDocument {
     version: number;
     isDirty: boolean;
     lineCount: number;
+    isClosed: boolean;
+    eol: vscode.EndOfLine;
 
     constructor(text: string) {
         this.setLines(text);

--- a/test/systemTests/resources/largeFileIsNotFormatted-expected.md
+++ b/test/systemTests/resources/largeFileIsNotFormatted-expected.md
@@ -1,0 +1,1127 @@
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer

--- a/test/systemTests/resources/largeFileIsNotFormatted-input.md
+++ b/test/systemTests/resources/largeFileIsNotFormatted-input.md
@@ -1,0 +1,1127 @@
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer
+
+|Type | Range|	Size
+|-|-|-
+|sbyte |	-128 to 127|	Signed 8-bit integer
+|byte|	0 to 255|	Unsigned 8-bit integer
+|char|	U+0000 to U+ffff|	Unicode 16-bit character
+|short|	-32,768 to 32,767|	Signed 16-bit integer
+|ushort|	0 to 65,535|	Unsigned 16-bit integer
+|int|	-2,147,483,648 to 2,147,483,647|	Signed 32-bit integer
+|uint|	0 to 4,294,967,295|	Unsigned 32-bit integer
+|long|	-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|	Signed 64-bit integer
+|ulong|	0 to 18,446,744,073,709,551,615|	Unsigned 64-bit integer

--- a/test/systemTests/tableRangePrettyfierFactory.ts
+++ b/test/systemTests/tableRangePrettyfierFactory.ts
@@ -2,24 +2,24 @@ import * as assert from 'assert';
 import * as vscode from "vscode";
 import * as fs from 'fs';
 import * as path from 'path';
+import { SizeLimitChecker } from '../../src/extension/sizeLimitCheker';
+import { TableDocumentPrettyfier } from '../../src/extension/tableDocumentPrettyfier';
 import { TableDocumentRangePrettyfier } from "../../src/extension/tableDocumentRangePrettyfier";
-import { TableFactory } from "../../src/modelFactory/tableFactory";
-import { AlignmentFactory } from "../../src/modelFactory/alignmentFactory";
-import { TableValidator } from "../../src/modelFactory/tableValidator";
-import { TableViewModelFactory } from "../../src/viewModelFactories/tableViewModelFactory";
-import { RowViewModelFactory } from "../../src/viewModelFactories/rowViewModelFactory";
-import { ContentPadCalculator } from "../../src/padCalculation/contentPadCalculator";
-import { TableStringWriter } from "../../src/writers/tableStringWriter";
 import { ILogger } from "../../src/diagnostics/logger";
 import { ConsoleLogger } from '../../src/diagnostics/consoleLogger';
-import { MarkdownTextDocumentStub } from "../stubs/markdownTextDocumentStub";
+import { AlignmentFactory } from "../../src/modelFactory/alignmentFactory";
+import { SelectionInterpreter } from '../../src/modelFactory/selectionInterpreter';
 import { TrimmerTransformer } from '../../src/modelFactory/transformers/trimmerTransformer';
 import { BorderTransformer } from '../../src/modelFactory/transformers/borderTransformer';
-import { SelectionInterpreter } from '../../src/modelFactory/selectionInterpreter';
+import { TableFactory } from "../../src/modelFactory/tableFactory";
+import { TableValidator } from "../../src/modelFactory/tableValidator";
+import { ContentPadCalculator } from "../../src/padCalculation/contentPadCalculator";
 import { PadCalculatorSelector } from '../../src/padCalculation/padCalculatorSelector';
-import { AlignmentMarkerStrategy } from '../../src/viewModelFactories/alignmentMarking';
-import { TableDocumentPrettyfier } from '../../src/extension/tableDocumentPrettyfier';
 import { TableFinder } from '../../src/tableFinding/tableFinder';
+import { AlignmentMarkerStrategy } from '../../src/viewModelFactories/alignmentMarking';
+import { RowViewModelFactory } from "../../src/viewModelFactories/rowViewModelFactory";
+import { TableViewModelFactory } from "../../src/viewModelFactories/tableViewModelFactory";
+import { TableStringWriter } from "../../src/writers/tableStringWriter";
 
 export class PrettyfierFromFile {
     private readonly _logger: ILogger;
@@ -80,8 +80,10 @@ export class PrettyfierFromFile {
                     new AlignmentMarkerStrategy(":")
                 )),
                 new TableStringWriter(),
-                [ this._logger ]
-            )
+                [ this._logger ],
+                new SizeLimitChecker([ this._logger ], 50000)
+            ),
+            new SizeLimitChecker([ this._logger ], 50000)
         );
     }
 }

--- a/test/unitTests/extension/sizeLimitChecker.test.ts
+++ b/test/unitTests/extension/sizeLimitChecker.test.ts
@@ -1,0 +1,49 @@
+import * as assert from 'assert';
+import { IMock, Mock, It, Times } from "typemoq";
+import { SizeLimitChecker } from '../../../src/extension/sizeLimitCheker';
+import { ILogger } from '../../../src/diagnostics/logger';
+
+suite("SizeLimitCheker Tests", () => {
+
+    let _logger: IMock<ILogger>;
+
+    setup(() => {
+        _logger = Mock.ofType<ILogger>();
+    });
+
+    test("isWithinAllowedSizeLimit() with empty text returns true", () => {
+        const sut = createSut();
+
+        const result = sut.isWithinAllowedSizeLimit("");
+
+        assert.equal(result, true);
+    });
+
+    test("isWithinAllowedSizeLimit() with 1 char and 0 limit returns false", () => {
+        const sut = createSut(0);
+
+        const result = sut.isWithinAllowedSizeLimit("a");
+
+        assert.equal(result, false);
+    });
+
+    test("isWithinAllowedSizeLimit() with 2 char and 2 char limit returns true", () => {
+        const sut = createSut(2);
+
+        const result = sut.isWithinAllowedSizeLimit("ab");
+
+        assert.equal(result, true);
+    });
+
+    test("isWithinAllowedSizeLimit() with 2 char and 3 char limit returns false", () => {
+        const sut = createSut(2);
+
+        const result = sut.isWithinAllowedSizeLimit("abc");
+
+        assert.equal(result, false);
+    });
+
+    function createSut(limit: number = 100): SizeLimitChecker {
+        return new SizeLimitChecker([_logger.object], limit);
+    }
+});


### PR DESCRIPTION
Associated to issue #30 