### PR TITLE
FEAT: Context Menu Quick Formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,10 @@
       {
         "command": "markdownTablePrettify.prettifyTables",
         "title": "Prettify markdown tables"
+      },
+      {
+        "command": "markdownTablePrettify.prettifyTableAtCursor",
+        "title": "Prettify markdown table at cursor"
       }
     ],
     "keybindings": [
@@ -67,7 +71,16 @@
         "mac": "cmd+alt+m",
         "when": "editorTextFocus && !editorReadonly && !inCompositeEditor"
       }
-    ]
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "markdownTablePrettify.prettifyTableAtCursor",
+          "when": "editorTextFocus && !editorReadonly && !inCompositeEditor",
+          "group": "1_modification"
+        }
+      ]
+    }
   },
   "capabilities": {
     "documentFormattingProvider": "true"

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -1,6 +1,6 @@
 'use strict';
 import * as vscode from 'vscode';
-import { getSupportLanguageIds, getDocumentRangePrettyfier, getDocumentPrettyfier, getDocumentPrettyfierCommand, invalidateCache } from './prettyfierFactory';
+import { getSupportLanguageIds, getDocumentRangePrettyfier, getDocumentPrettyfier, getDocumentPrettyfierCommand, getTableAtCursorPrettyfier, invalidateCache } from './prettyfierFactory';
 
 // This method is called when the extension is activated.
 // The extension is activated the very first time the command is executed.
@@ -28,6 +28,15 @@ export function activate(context: vscode.ExtensionContext): void {
         vscode.commands.registerTextEditorCommand(command, textEditor => {
             if (supportedLanguageIds.indexOf(textEditor.document.languageId) >= 0)
                 getDocumentPrettyfierCommand().prettifyDocument(textEditor);
+        })
+    );
+
+    const formatTableCommand = "markdownTablePrettify.formatTableAtCursor";
+    context.subscriptions.push(
+        vscode.commands.registerTextEditorCommand(formatTableCommand, textEditor => {
+            if (supportedLanguageIds.indexOf(textEditor.document.languageId) >= 0) {
+                const found = getTableAtCursorPrettyfier().prettifyTableAtCursor(textEditor);
+            }
         })
     );
 }

--- a/src/extension/prettyfierFactory.ts
+++ b/src/extension/prettyfierFactory.ts
@@ -20,14 +20,17 @@ import { SelectionInterpreter } from '../modelFactory/selectionInterpreter';
 import { PadCalculatorSelector } from '../padCalculation/padCalculatorSelector';
 import { AlignmentMarkerStrategy } from '../viewModelFactories/alignmentMarking';
 import { MultiTablePrettyfier } from '../prettyfiers/multiTablePrettyfier';
+import { TableAtCursorPrettyfier } from "../prettyfiers/tableAtCursorPrettyfier";
 import { SingleTablePrettyfier } from '../prettyfiers/singleTablePrettyfier';
 import { TableStringWriter } from "../writers/tableStringWriter";
 import { ValuePaddingProvider } from '../writers/valuePaddingProvider';
 
 let cachedMultiTablePrettyfier: MultiTablePrettyfier | null = null;
+let cachedTableAtCursorPrettyfier: TableAtCursorPrettyfier | null = null;
 
 export function invalidateCache() {
     cachedMultiTablePrettyfier = null;
+    cachedTableAtCursorPrettyfier = null;
 }
 
 export function getSupportLanguageIds() {
@@ -62,6 +65,23 @@ function getMultiTablePrettyfier(): MultiTablePrettyfier {
     );
 
     return cachedMultiTablePrettyfier;
+}
+
+export function getTableAtCursorPrettyfier(): TableAtCursorPrettyfier {
+    if (cachedTableAtCursorPrettyfier) {
+        return cachedTableAtCursorPrettyfier;
+    }
+
+    const loggers = getLoggers();
+    const sizeLimitChecker = getSizeLimitChecker(loggers);
+    const columnPadding = getConfigurationValue<number>("columnPadding", 0);
+
+    cachedTableAtCursorPrettyfier = new TableAtCursorPrettyfier(
+        new TableFinder(new TableValidator(new SelectionInterpreter(true))),
+        getSingleTablePrettyfier(loggers, sizeLimitChecker, columnPadding)
+    );
+
+    return cachedTableAtCursorPrettyfier;
 }
 
 function getSingleTablePrettyfier(loggers: ILogger[], sizeLimitCheker: ConfigSizeLimitChecker, columnPadding: number): SingleTablePrettyfier {

--- a/src/prettyfiers/tableAtCursorPrettyfier.ts
+++ b/src/prettyfiers/tableAtCursorPrettyfier.ts
@@ -1,0 +1,59 @@
+import * as vscode from "vscode";
+import { TableFinder } from "../tableFinding/tableFinder";
+import { SingleTablePrettyfier } from "../prettyfiers/singleTablePrettyfier";
+import { Document } from "../models/doc/document";
+import { Range } from "../models/doc/range";
+
+export class TableAtCursorPrettyfier {
+
+    constructor(
+        private readonly _tableFinder: TableFinder,
+        private readonly _singleTablePrettyfier: SingleTablePrettyfier
+    ) { }
+
+    public prettifyTableAtCursor(editor: vscode.TextEditor): boolean {
+        const cursorLine = editor.selection.active.line;
+        const document = new Document(editor.document.getText());
+
+        const tableRange = this.findTableRangeAtLine(document, cursorLine);
+        if (tableRange == null) {
+            return false;
+        }
+
+        const formattedTable = this._singleTablePrettyfier.prettifyTable(document, tableRange);
+
+        editor.edit(editBuilder => {
+            editBuilder.replace(
+                new vscode.Range(
+                    new vscode.Position(tableRange.startLine, 0),
+                    new vscode.Position(tableRange.endLine, Number.MAX_SAFE_INTEGER)
+                ),
+                formattedTable
+            );
+        });
+
+        return true;
+    }
+
+    private findTableRangeAtLine(document: Document, cursorLine: number): Range | null {
+        const searchStart = Math.max(0, cursorLine - 1);
+        let searchFrom = 0;
+
+        let candidate: Range | null = null;
+        while (true) {
+            const range = this._tableFinder.getNextRange(document, searchFrom);
+            if (range == null) break;
+
+            if (range.startLine <= cursorLine && cursorLine <= range.endLine) {
+                candidate = range;
+                break;
+            }
+
+            if (range.startLine > cursorLine) break;
+
+            searchFrom = range.endLine + 1;
+        }
+
+        return candidate;
+    }
+}


### PR DESCRIPTION
Thanks for the plugin, it works perfectly!

I've added a small feature which adds a context menu entry so a table can be formatted using just "Right-Click" -> "Prettify markdown table at cursor". 

If this is too intrusive, a setting could be added to disable this feature.

Hoping for your feedback on this and would love to see it merged. I do not want to maintain a fork just for this :)

<img width="1080" height="608" alt="demo" src="https://github.com/user-attachments/assets/cccd160e-09f9-4a2d-a343-1e89e35a4b1c" />